### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 # .github/workflows/ci.yml
 name: Python CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/aureseth/Copilot-career/security/code-scanning/1](https://github.com/aureseth/Copilot-career/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow that restricts the `GITHUB_TOKEN` to the minimum required privileges. In this case, the workflow performs actions like checking out the repository, setting up Python, installing dependencies, linting, type checking, and running tests. None of these actions require write access to the repository.

The least privilege permissions required are:
- `contents: read` to allow reading the repository content.

The `permissions` block should be added at the root of the workflow (outside the `jobs` section) to apply to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
